### PR TITLE
Here is the change I mentioned yesterday.

### DIFF
--- a/quicommon/TabSet.qui
+++ b/quicommon/TabSet.qui
@@ -76,12 +76,16 @@ TabSet.prototype.extend({
         // TODO: If buttons are moved elsewhere, unbind click event.
         var self = this;
         this.buttons().click(function() {
-            if (self.selectTabOnClick())
+            var buttonIndex = self.buttons().index(this);
+            if (buttonIndex >= 0)
             {
-                var buttonIndex = self.buttons().index(this);
-                if (buttonIndex >= 0)
+                if (self.selectTabOnClick())
                 {
                     self.selectedTabIndex(buttonIndex);
+                }
+                else
+                {
+                    self.trigger("onTabClicked", [ buttonIndex, self.tabs()[buttonIndex] ]);
                 }
             }
         });


### PR DESCRIPTION
Tabset still wires up a click event even if it doesn't select the tab itself (on click).
